### PR TITLE
Support for OriginalRecipient field

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $inbound->FromEmail();
 $inbound->FromFull();
 $inbound->FromName();
 $inbound->Date();
+$inbound->OriginalRecipient();
 $inbound->ReplyTo();
 $inbound->MailboxHash();
 $inbound->Tag();

--- a/fixtures/inbound.json
+++ b/fixtures/inbound.json
@@ -26,6 +26,7 @@
       "Name": "Another Cc"
     }
   ],
+  "OriginalRecipient": "451d9b70cf9364d23ff6f9d51d870251569e+ahoy@inbound.postmarkapp.com",
   "ReplyTo": "myUsersReplyAddress@theirDomain.com",
   "Subject": "This is an inbound message",
   "MessageID": "22c74902-a0c1-4511-804f2-341342852c90",

--- a/test/Postmark/Tests/InboundTest.php
+++ b/test/Postmark/Tests/InboundTest.php
@@ -32,6 +32,11 @@ class Postmark_Tests_Inbound extends PHPUnit_Framework_TestCase {
         $this->assertEquals($this->inbound->Date(), 'Thu, 5 Apr 2012 16:59:01 +0200');
     }
 
+    public function testOriginalRecipient()
+    {
+        $this->assertEquals($this->inbound->OriginalRecipient(), '451d9b70cf9364d23ff6f9d51d870251569e+ahoy@inbound.postmarkapp.com');
+    }
+
     public function testReplyTo()
     {
         $this->assertEquals($this->inbound->ReplyTo(), 'myUsersReplyAddress@theirDomain.com');


### PR DESCRIPTION
As of this year, Postmark now includes an additional field to distinguish to which inbound address an email has been sent. This patch documents and tests this small change.

Blog post: http://blog.postmarkapp.com/post/108186963043/postmark-features-update