### PR TITLE
Fix undefined variable error on PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,11 @@ script: phpunit
 php:
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
+  - 7
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: 7

--- a/lib/Postmark/Inbound.php
+++ b/lib/Postmark/Inbound.php
@@ -69,24 +69,20 @@ class Inbound {
 
     public function Headers($name = 'X-Spam-Status')
     {
-        foreach($this->Source->Headers as $header)
+        foreach ($this->Source->Headers as $header)
         {
-            if(isset($header->Name) AND $header->Name == $name)
+            if (isset($header->Name) AND $header->Name == $name)
             {
-                if($header->Name == 'Received-SPF')
+                if ($header->Name == 'Received-SPF')
                 {
                     return self::_parseReceivedSpf($header->Value);
                 }
 
                 return $header->Value;
             }
-            else
-            {
-                unset($header);
-            }
         }
 
-        return $header ? $header : FALSE;
+        return FALSE;
     }
 
     private static function _parseReceivedSpf($header)


### PR DESCRIPTION
I have experienced a PHP error on this line: https://github.com/jjaffeux/postmark-inbound-php/blob/1cdc9b2d620487a6fbb1171eca7e07fb2fb1e386/lib/Postmark/Inbound.php#L89 about the `$header` variable being undefined.

This has happened on PHP 5.6 with the Postmark webhook check request:

``` json
{"FromName":"Postmarkapp Support","From":"support@postmarkapp.com","FromFull":{"Email":"support@postmarkapp.com","Name":"Postmarkapp Support","MailboxHash":""},"To":"\"Firstname Lastname\" <mailbox+SampleHash@inbound.postmarkapp.com>","ToFull":[{"Email":"mailbox+SampleHash@inbound.postmarkapp.com","Name":"Firstname Lastname","MailboxHash":"SampleHash"}],"Cc":"\"First Cc\" <firstcc@postmarkapp.com>, secondCc@postmarkapp.com","CcFull":[{"Email":"firstcc@postmarkapp.com","Name":"First Cc","MailboxHash":""},{"Email":"secondCc@postmarkapp.com","Name":"","MailboxHash":""}],"Bcc":"\"First Bcc\" <firstbcc@postmarkapp.com>, secondbcc@postmarkapp.com","BccFull":[{"Email":"firstbcc@postmarkapp.com","Name":"First Bcc","MailboxHash":""},{"Email":"secondbcc@postmarkapp.com","Name":"","MailboxHash":""}],"OriginalRecipient":"mailbox+SampleHash@inbound.postmarkapp.com","Subject":"Test subject","MessageID":"73e6d360-66eb-11e1-8e72-a8904824019b","ReplyTo":"replyto@postmarkapp.com","MailboxHash":"SampleHash","Date":"Mon, 21 Sep 2015 08:17:50 -0400","TextBody":"This is a test text body.","HtmlBody":"&lt;html&gt;&lt;body&gt;&lt;p&gt;This is a test html body.&lt;\/p&gt;&lt;\/body&gt;&lt;\/html&gt;","StrippedTextReply":"This is the reply text","Tag":"TestTag","Headers":[{"Name":"X-Header-Test","Value":""}],"Attachments":[{"Name":"test.txt","Content":"VGhpcyBpcyBhdHRhY2htZW50IGNvbnRlbnRzLCBiYXNlLTY0IGVuY29kZWQu","ContentType":"text\/plain","ContentLength":45}]}
```

While I am executing:

``` php
$inbound = new \Postmark\Inbound($json);
$inbound->Headers('X-Spam-Status');
```