### PR TITLE
Upgrade for attachment

### DIFF
--- a/lib/Postmark/Attachment.php
+++ b/lib/Postmark/Attachment.php
@@ -2,21 +2,21 @@
 
 namespace Postmark;
 
-Class Attachment extends \Postmark\Inbound {
+Class Attachment {
 
     public function __construct($attachment)
     {
-        $this->Attachment = $attachment;
-        $this->Name = $this->Attachment->Name;
-        $this->ContentType = $this->Attachment->ContentType;
-        $this->ContentLength = $this->Attachment->ContentLength;
-        $this->Content = $this->Attachment->Content;
-        $this->ContentID = array_key_exists('ContentID', $this->Attachment) ? $this->Attachment->ContentID : NULL; // Allows to use the attribute 'ContentID' if it exists. Returns NULL if it does not exist or the value of 'ContentID' if it does.
+//        $this->Attachment = $attachment;
+        $this->Name = $attachment->Name;
+        $this->ContentType = $attachment->ContentType;
+        $this->ContentLength = $attachment->ContentLength;
+        $this->Content = $attachment->Content;
+        $this->ContentID = property_exists($attachment, 'ContentID') ? $attachment->ContentID : NULL; // Allows to use the attribute 'ContentID' if it exists. Returns NULL if it does not exist or the value of 'ContentID' if it does.
     }
 
     private function _read()
     {
-        return base64_decode(chunk_split($this->Attachment->Content));
+        return base64_decode(chunk_split($this->Content));
     }
     
     public function Download($directory)

--- a/lib/Postmark/Attachment.php
+++ b/lib/Postmark/Attachment.php
@@ -11,6 +11,7 @@ Class Attachment extends \Postmark\Inbound {
         $this->ContentType = $this->Attachment->ContentType;
         $this->ContentLength = $this->Attachment->ContentLength;
         $this->Content = $this->Attachment->Content;
+        $this->ContentID = array_key_exists('ContentID', $this->Attachment) ? $this->Attachment->ContentID : NULL; // Allows to use the attribute 'ContentID' if it exists. Returns NULL if it does not exist or the value of 'ContentID' if it does.
     }
 
     private function _read()

--- a/lib/Postmark/Attachments.php
+++ b/lib/Postmark/Attachments.php
@@ -2,7 +2,7 @@
 
 namespace Postmark;
 
-Class Attachments extends \Postmark\Inbound  implements \Iterator {
+Class Attachments implements \Iterator {
 
     public function __construct($attachments)
     {


### PR DESCRIPTION
I suggest the following changes to improve support for attachments.

- adding a property to the Attachment class that retrieves the value of the ContentID attribute if it exists, or returns the NULL value. This makes it possible to differentiate a normal attachment, an attachment included in the mail body, such as an image.

- deleting the Attachment and Attachment class extensions because the Source and Json properties are unnecessary.