### PR TITLE
Support of "Content-ID" for attachements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 script: phpunit
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/lib/Postmark/Attachment.php
+++ b/lib/Postmark/Attachment.php
@@ -2,21 +2,21 @@
 
 namespace Postmark;
 
-Class Attachment extends \Postmark\Inbound {
+Class Attachment {
 
     public function __construct($attachment)
     {
-        $this->Attachment = $attachment;
-        $this->Name = $this->Attachment->Name;
-        $this->ContentType = $this->Attachment->ContentType;
-        $this->ContentLength = $this->Attachment->ContentLength;
-        $this->Content = $this->Attachment->Content;
-        $this->ContentID = array_key_exists('ContentID', $this->Attachment) ? $this->Attachment->ContentID : NULL; // Allows to use the attribute 'ContentID' if it exists. Returns NULL if it does not exist or the value of 'ContentID' if it does.
+//        $this->Attachment = $attachment;
+        $this->Name = $attachment->Name;
+        $this->ContentType = $attachment->ContentType;
+        $this->ContentLength = $attachment->ContentLength;
+        $this->Content = $attachment->Content;
+        $this->ContentID = property_exists($attachment, 'ContentID') ? $attachment->ContentID : NULL; // Allows to use the attribute 'ContentID' if it exists. Returns NULL if it does not exist or the value of 'ContentID' if it does.
     }
 
     private function _read()
     {
-        return base64_decode(chunk_split($this->Attachment->Content));
+        return base64_decode(chunk_split($this->Content));
     }
     
     public function Download($directory)

--- a/lib/Postmark/Attachment.php
+++ b/lib/Postmark/Attachment.php
@@ -11,6 +11,7 @@ Class Attachment extends \Postmark\Inbound {
         $this->ContentType = $this->Attachment->ContentType;
         $this->ContentLength = $this->Attachment->ContentLength;
         $this->Content = $this->Attachment->Content;
+        $this->ContentID = array_key_exists('ContentID', $this->Attachment) ? $this->Attachment->ContentID : NULL; // Allows to use the attribute 'ContentID' if it exists. Returns NULL if it does not exist or the value of 'ContentID' if it does.
     }
 
     private function _read()

--- a/lib/Postmark/Attachment.php
+++ b/lib/Postmark/Attachment.php
@@ -2,11 +2,10 @@
 
 namespace Postmark;
 
-Class Attachment {
+Class Attachment extends \Postmark\Inbound {
 
     public function __construct($attachment)
     {
-//        $this->Attachment = $attachment;
         $this->Name = $attachment->Name;
         $this->ContentType = $attachment->ContentType;
         $this->ContentLength = $attachment->ContentLength;


### PR DESCRIPTION
I propose you the following modifications for the support of the properties "Content-ID" for the attachments of the mails.