### PR TITLE
Rename file to conform to psr-0 expectations

### DIFF
--- a/lib/Postmark/Exception.php
+++ b/lib/Postmark/Exception.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Postmark;
-
-class InboundException extends \Exception {}

--- a/lib/Postmark/InboundException.php
+++ b/lib/Postmark/InboundException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Postmark;
+
+class InboundException extends \Exception {}


### PR DESCRIPTION
This renaming prevents the following deprecation notice:

```
Deprecation Notice: Class Postmark\InboundException located in ./vendor/jjaffeux/postmark-inbound-php/lib/Postmark/Exception.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
```